### PR TITLE
添加UMASK_SET参数

### DIFF
--- a/root/etc/services.d/qBittorrent/run
+++ b/root/etc/services.d/qBittorrent/run
@@ -1,5 +1,9 @@
 #!/usr/bin/with-contenv bash
 
+UMASK_SET=${UMASK_SET:-022}
+
+umask "$UMASK_SET"
+
 # 启动qBittorrent
 exec \
 	s6-setuidgid abc qbittorrent-nox --webui-port=$WEBUIPORT --profile=/config 


### PR DESCRIPTION
添加UMASK_SET参数，可以设置UMASK，防止使用nobody为拥有者时文件权限644，导致其他用户组没有写权限